### PR TITLE
创建admin证书描述错误

### DIFF
--- a/02-创建TLS证书和秘钥.md
+++ b/02-创建TLS证书和秘钥.md
@@ -204,7 +204,7 @@ $ cat admin-csr.json
 
 + 后续 `kube-apiserver` 使用 `RBAC` 对客户端(如 `kubelet`、`kube-proxy`、`Pod`)请求进行授权；
 + `kube-apiserver` 预定义了一些 `RBAC` 使用的 `RoleBindings`，如 `cluster-admin` 将 Group `system:masters` 与 Role `cluster-admin` 绑定，该 Role 授予了调用`kube-apiserver` **所有 API**的权限；
-+ OU 指定该证书的 Group 为 `system:masters`，`kubelet` 使用该证书访问 `kube-apiserver` 时 ，由于证书被 CA 签名，所以认证通过，同时由于证书用户组为经过预授权的 `system:masters`，所以被授予访问所有 API 的权限；
++ O 指定该证书的 Group 为 `system:masters`，`kubelet` 使用该证书访问 `kube-apiserver` 时 ，由于证书被 CA 签名，所以认证通过，同时由于证书用户组为经过预授权的 `system:masters`，所以被授予访问所有 API 的权限；
 
 生成 admin 证书和私钥：
 


### PR DESCRIPTION
创建admin证书描述错误,OU 指定该证书的 Group 为 `system:masters` 改为O 指定该证书的 Group 为 `system:masters`，