### PR TITLE
根据文档例子改写Vagrantfile配置

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  ips = ["10.64.3.7", "10.64.3.8", "10.64.3.86"]
+  ips = ["10.64.3.7", "10.64.3.8", "10.66.3.86"]
   (0..2).each do |id|
     mid = id + 1
     config.vm.define "kube-node#{mid}" do |node|


### PR DESCRIPTION
根据文档，第三台虚拟机的ip应该为`10.66.3.86`，这个小问题不容易被发现，但是会对用户的正常使用造成困扰。