### PR TITLE
change --cluster-cidr=$SERVICE_CIDR for kube-proxy to --cluster-cidr=$CLUSTER_CIDR

### DIFF
--- a/07-部署Node节点.md
+++ b/07-部署Node节点.md
@@ -353,7 +353,7 @@ WorkingDirectory=/var/lib/kube-proxy
 ExecStart=/root/local/bin/kube-proxy \\
   --bind-address=${NODE_IP} \\
   --hostname-override=${NODE_IP} \\
-  --cluster-cidr=${SERVICE_CIDR} \\
+  --cluster-cidr=${CLUSTER_CIDR} \\
   --kubeconfig=/etc/kubernetes/kube-proxy.kubeconfig \\
   --logtostderr=true \\
   --v=2
@@ -367,7 +367,7 @@ EOF
 ```
 
 + `--hostname-override` 参数值必须与 kubelet 的值一致，否则 kube-proxy 启动后会找不到该 Node，从而不会创建任何 iptables 规则；
-+ `--cluster-cidr` 必须与 kube-apiserver 的 `--service-cluster-ip-range` 选项值一致；
++ `--cluster-cidr` 必须与 kube-controller-manager 的 `--cluster-cidr` 选项值一致；
 + kube-proxy 根据 `--cluster-cidr` 判断集群内部和外部流量，指定 `--cluster-cidr` 或 `--masquerade-all` 选项后 kube-proxy 才会对访问 Service IP 的请求做 SNAT；
 + `--kubeconfig` 指定的配置文件嵌入了 kube-apiserver 的地址、用户名、证书、秘钥等请求和认证信息；
 + 预定义的 RoleBinding `cluster-admin` 将User `system:kube-proxy` 与 Role `system:node-proxier` 绑定，该 Role 授予了调用 `kube-apiserver` Proxy 相关 API 的权限；

--- a/systemd/kube-proxy.service
+++ b/systemd/kube-proxy.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 ExecStart=/root/local/bin/kube-proxy \
   --bind-address=10.64.3.7 \
-  --cluster-cidr=10.254.0.0/16 \
+  --cluster-cidr=172.30.0.0/16 \
   --hostname-override=10.64.3.7 \
   --kubeconfig=/etc/kubernetes/kube-proxy.kubeconfig \
   --logtostderr=true \


### PR DESCRIPTION
the option --cluster-cidr for kube-proxy is not right, most for networkpolicy that is sensitive to snat.