### PR TITLE
env: modprobe before setting env

### DIFF
--- a/01.系统初始化和全局变量.md
+++ b/01.系统初始化和全局变量.md
@@ -144,6 +144,13 @@ $ sudo service dnsmasq stop
 $ sudo systemctl disable dnsmasq
 ```
 
+## 加载内核模块
+
+``` bash
+$ sudo modprobe br_netfilter
+$ sudo modprobe ip_vs
+```
+
 ## 设置系统参数
 
 ``` bash
@@ -159,13 +166,6 @@ EOF
 $ sudo cp kubernetes.conf  /etc/sysctl.d/kubernetes.conf
 $ sudo sysctl -p /etc/sysctl.d/kubernetes.conf
 $ sudo mount -t cgroup -o cpu,cpuacct none /sys/fs/cgroup/cpu,cpuacct
-```
-
-## 加载内核模块
-
-``` bash
-$ sudo modprobe br_netfilter
-$ sudo modprobe ip_vs
 ```
 
 ## 设置系统时区


### PR DESCRIPTION
net.bridge.bridge-nf-call-iptables 和 net.bridge.bridge-nf-call-ip6tables 需要在加载 br_netfilter 之后才存在，如果在加载之前通过 sysctl 设置，会导致设置失败