### PR TITLE
Update 04.部署etcd集群.md

### DIFF
--- a/04.部署etcd集群.md
+++ b/04.部署etcd集群.md
@@ -78,6 +78,7 @@ EOF
 cfssl gencert -ca=/etc/kubernetes/cert/ca.pem \
     -ca-key=/etc/kubernetes/cert/ca-key.pem \
     -config=/etc/kubernetes/cert/ca-config.json \
+    -hostname='127.0.0.1,172.27.129.105,172.27.129.111,172.27.129.112' \
     -profile=kubernetes etcd-csr.json | cfssljson -bare etcd
 ls etcd*
 ```


### PR DESCRIPTION
move hostname from config file into cli command line. Avoid ` [WARNING] This certificate lacks a "hosts" field.`