### PR TITLE
fix Keepalived_vrrp: Cannot find script killall in path

### DIFF
--- a/06-1.ha.md
+++ b/06-1.ha.md
@@ -20,7 +20,7 @@ source /opt/k8s/bin/environment.sh
 for node_ip in ${NODE_IPS[@]}
   do
     echo ">>> ${node_ip}"
-    ssh root@${node_ip} "yum install -y keepalived haproxy"
+    ssh root@${node_ip} "yum install -y keepalived haproxy psmisc"
   done
 ```
 


### PR DESCRIPTION
/var/log/messages:
Keepalived_vrrp[1080]: WARNING - default user 'keepalived_script' for script execution does not exist - please create.
Keepalived_vrrp[1080]: Cannot find script killall in path
