### PR TITLE
use '\EOF' for heredoc escaping

### DIFF
--- a/06-0.apiserver高可用之nginx代理.md
+++ b/06-0.apiserver高可用之nginx代理.md
@@ -133,7 +133,7 @@ for node_ip in ${NODE_IPS[@]}
 
 ``` bash
 cd /opt/k8s/work
-cat > kube-nginx.conf <<EOF
+cat > kube-nginx.conf << \EOF
 worker_processes 1;
 
 events {


### PR DESCRIPTION
Without escaping, $remote_addr will be interpreted as empty string ""