### PR TITLE
Update 06-2.apiserver集群.md

### DIFF
--- a/06-2.apiserver集群.md
+++ b/06-2.apiserver集群.md
@@ -499,7 +499,7 @@ EOF
 
 注意：
 1. requestheader-client-ca-file 指定的 CA 证书，必须具有 client auth and server auth；
-2. 如果 `--requestheader-allowed-names` 为空，或者 `--proxy-client-cert-file` 证书的 CN 名称不在 allowed-names 中，则后续查看 node 或 pods 的 metrics 失败，提示：
+2. 如果 `--requestheader-allowed-names`  不为空，且 `--proxy-client-cert-file` 证书的 CN 名称不在 allowed-names 中，则后续查看 node 或 pods 的 metrics 失败，提示：
   ``` bash
   [root@zhangjun-k8s01 1.8+]# kubectl top nodes
   Error from server (Forbidden): nodes.metrics.k8s.io is forbidden: User "aggregator" cannot list resource "nodes" in API group "metrics.k8s.io" at the cluster scope


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/

The connection must be made using a client certificate whose CN is one of those listed in --requestheader-allowed-names. Note: You can set this option to blank as --requestheader-allowed-names="". This will indicate to an extension apiserver that any CN is acceptable.