### PR TITLE
fix flannel Sublen to 24

### DIFF
--- a/05.部署flannel网络.md
+++ b/05.部署flannel网络.md
@@ -217,7 +217,7 @@ etcdctl \
 
 输出：
 
-`{"Network":"172.30.0.0/16", "SubnetLen": 21, "Backend": {"Type": "vxlan"}}`
+`{"Network":"172.30.0.0/16", "SubnetLen": 24, "Backend": {"Type": "vxlan"}}`
 
 查看已分配的 Pod 子网段列表(/24):
 
@@ -234,9 +234,9 @@ etcdctl \
 输出（结果视部署情况而定）：
 
 ``` bash
-/kubernetes/network/subnets/172.30.80.0-21
-/kubernetes/network/subnets/172.30.32.0-21
-/kubernetes/network/subnets/172.30.184.0-21
+/kubernetes/network/subnets/172.30.80.0-24
+/kubernetes/network/subnets/172.30.32.0-24
+/kubernetes/network/subnets/172.30.184.0-24
 ```
 
 查看某一 Pod 网段对应的节点 IP 和 flannel 接口地址:
@@ -248,7 +248,7 @@ etcdctl \
   --ca-file=/etc/kubernetes/cert/ca.pem \
   --cert-file=/etc/flanneld/cert/flanneld.pem \
   --key-file=/etc/flanneld/cert/flanneld-key.pem \
-  get ${FLANNEL_ETCD_PREFIX}/subnets/172.30.80.0-21
+  get ${FLANNEL_ETCD_PREFIX}/subnets/172.30.80.0-24
 ```
 
 输出（结果视部署情况而定）：
@@ -279,11 +279,11 @@ etcdctl \
 
 ``` bash
 [root@zhangjun-k8s01 work]# ip route show |grep flannel.1
-172.30.32.0/21 via 172.30.32.0 dev flannel.1 onlink
-172.30.184.0/21 via 172.30.184.0 dev flannel.1 onlink
-``` 
+172.30.32.0/24 via 172.30.32.0 dev flannel.1 onlink
+172.30.184.0/24 via 172.30.184.0 dev flannel.1 onlink
+```
 + 到其它节点 Pod 网段请求都被转发到 flannel.1 网卡；
-+ flanneld 根据 etcd 中子网段的信息，如 `${FLANNEL_ETCD_PREFIX}/subnets/172.30.80.0-21` ，来决定进请求发送给哪个节点的互联 IP；
++ flanneld 根据 etcd 中子网段的信息，如 `${FLANNEL_ETCD_PREFIX}/subnets/172.30.80.0-24` ，来决定进请求发送给哪个节点的互联 IP；
 
 ## 验证各节点能通过 Pod 网段互通
 


### PR DESCRIPTION
kubeleti里面设置的maxPods的值是: 220，每台机器最多只能跑220个容器，一个c段ip就足够了

SubnetLen值为21， CLUSTER_CIDR是172.30.0.0/16，这样集群中有32个node就把地址池用完了

应该设置SubnetLen为24, 这样ip地址段足够分配给node上的容器，也能充分利用ip地址，集群中可以容纳256个节点