### PR TITLE
Update registry address from microsoft to ustc.

### DIFF
--- a/08-4.kube-prometheus插件.md
+++ b/08-4.kube-prometheus插件.md
@@ -31,7 +31,7 @@ kube-prometheus 是一整套监控解决方案，它使用 Prometheus 采集集�
 cd /opt/k8s/work
 git clone https://github.com/coreos/kube-prometheus.git
 cd kube-prometheus/
-sed -i -e 's_quay.io_quay.azk8s.cn_' manifests/*.yaml manifests/setup/*.yaml # 使用微软的 Registry
+sed -i -e 's_quay.io_quay.mirrors.ustc.edu.cn_' manifests/*.yaml manifests/setup/*.yaml # 使用中科大的 Registry
 kubectl apply -f manifests/setup # 安装 prometheus-operator
 kubectl apply -f manifests/ # 安装 promethes metric adapter
 ```


### PR DESCRIPTION
2020年4月后，Azure中国镜像已经不能使用。