### PR TITLE
update quay.io registry.

### DIFF
--- a/08-4.kube-prometheus插件.md
+++ b/08-4.kube-prometheus插件.md
@@ -31,7 +31,7 @@ kube-prometheus 是一整套监控解决方案，它使用 Prometheus 采集集�
 cd /opt/k8s/work
 git clone https://github.com/coreos/kube-prometheus.git
 cd kube-prometheus/
-sed -i -e 's_quay.io_quay.azk8s.cn_' manifests/*.yaml manifests/setup/*.yaml # 使用微软的 Registry
+sed -i -e 's_quay.io_quay.mirrors.ustc.edu.cn_' manifests/*.yaml manifests/setup/*.yaml # 使用中科大的 Registry
 kubectl apply -f manifests/setup # 安装 prometheus-operator
 kubectl apply -f manifests/ # 安装 promethes metric adapter
 ```

--- a/08-5.EFK插件.md
+++ b/08-5.EFK插件.md
@@ -30,8 +30,8 @@ EFK 目录是 `kubernetes/cluster/addons/fluentd-elasticsearch`。
 
 ``` bash
 cd /opt/k8s/work/kubernetes/cluster/addons/fluentd-elasticsearch
-sed -i -e 's_quay.io_quay.azk8s.cn_' es-statefulset.yaml # 使用微软的 Registry
-sed -i -e 's_quay.io_quay.azk8s.cn_' fluentd-es-ds.yaml # 使用微软的 Registry
+sed -i -e 's_quay.io_quay.mirrors.ustc.edu.cn_' es-statefulset.yaml # 使用中科大的 Registry
+sed -i -e 's_quay.io_quay.mirrors.ustc.edu.cn_' fluentd-es-ds.yaml # 使用中科大的 Registry
 ```
 
 ## 执行定义文件


### PR DESCRIPTION
自 2020年4月 起，Azure中国镜像已经不能使用
更换为中科大镜像后，经过测试，国内可以正常拉取