### PR TITLE
Update 05-4.scheduler集群.md

### DIFF
--- a/05-4.scheduler集群.md
+++ b/05-4.scheduler集群.md
@@ -25,7 +25,7 @@ tags: master, kube-scheduler
 为保证通信安全，本文档先生成 x509 证书和私钥，kube-scheduler 在如下两种情况下使用该证书：
 
 1. 与 kube-apiserver 的安全端口通信;
-2. 在**安全端口**(https，10251) 输出 prometheus 格式的 metrics；
+2. 在**非安全端口**(http，10251) 输出 prometheus 格式的 metrics；
 
 注意：如果没有特殊指明，本文档的所有操作**均在 zhangjun-k8s-01 节点上执行**。
 
@@ -192,12 +192,11 @@ ExecStart=/opt/k8s/bin/kube-scheduler \\
   --config=/etc/kubernetes/kube-scheduler.yaml \\
   --bind-address=##NODE_IP## \\
   --secure-port=10259 \\
-  --port=0 \\
   --tls-cert-file=/etc/kubernetes/cert/kube-scheduler.pem \\
   --tls-private-key-file=/etc/kubernetes/cert/kube-scheduler-key.pem \\
   --authentication-kubeconfig=/etc/kubernetes/kube-scheduler.kubeconfig \\
   --client-ca-file=/etc/kubernetes/cert/ca.pem \\
-  --requestheader-allowed-names="" \\
+  --requestheader-allowed-names="aggregator" \\
   --requestheader-client-ca-file=/etc/kubernetes/cert/ca.pem \\
   --requestheader-extra-headers-prefix="X-Remote-Extra-" \\
   --requestheader-group-headers=X-Remote-Group \\


### PR DESCRIPTION
修改在**非安全端口**(http，10251) 输出 prometheus 格式的 metrics；
去掉--port=0 \\；
修改--requestheader-allowed-names="aggregator" \\
否则，kube-scheduler启动不了。
