### PR TITLE
remove --requestheader-allowed-names option in kube-schedule.service

### DIFF
--- a/05-4.scheduler集群.md
+++ b/05-4.scheduler集群.md
@@ -197,7 +197,6 @@ ExecStart=/opt/k8s/bin/kube-scheduler \\
   --tls-private-key-file=/etc/kubernetes/cert/kube-scheduler-key.pem \\
   --authentication-kubeconfig=/etc/kubernetes/kube-scheduler.kubeconfig \\
   --client-ca-file=/etc/kubernetes/cert/ca.pem \\
-  --requestheader-allowed-names="" \\
   --requestheader-client-ca-file=/etc/kubernetes/cert/ca.pem \\
   --requestheader-extra-headers-prefix="X-Remote-Extra-" \\
   --requestheader-group-headers=X-Remote-Group \\


### PR DESCRIPTION
在使用'--requestheader-allowed-names'选项时，kube-scheduler一直在重启，并提示‘kube-scheduler[15418]: empty value in "requestheader-allowed-names"’，当我在service脚本中，将该选项移除后，再次重启kube-scheduler已经可以正常启动了。